### PR TITLE
`toast.promise` improvements

### DIFF
--- a/src/lib/stores.ts
+++ b/src/lib/stores.ts
@@ -126,6 +126,8 @@ const promise: ToastPromiseFunction = (promise, opts) => {
 			}
 			opts?.onFinish?.();
 		});
+
+	return promise;
 };
 
 const createStore = () => {

--- a/src/lib/stores.ts
+++ b/src/lib/stores.ts
@@ -108,11 +108,13 @@ const promise: ToastPromiseFunction = (promise, opts) => {
 
 	promise
 		.then((data) => {
-			addToast('success', opts.success, { opts, id });
+			const message = typeof opts.success === 'string' ? opts.success : opts.success(data);
+			addToast('success', message, { opts, id });
 			opts?.onSuccess?.(data);
 		})
 		.catch((err) => {
-			addToast('error', opts.error, { opts, id });
+			const message = typeof opts.error === 'string' ? opts.error : opts.error(err);
+			addToast('error', message, { opts, id });
 			opts?.onError?.(err);
 		})
 		.finally(() => {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -13,7 +13,7 @@ export type ToastType = 'info' | 'attention' | 'success' | 'warning' | 'error' |
 /** Simple helper to define the internal functions. */
 export type ToastFunction = (message: string, opts?: ToastFunctionOptions) => void;
 
-export type ToastPromiseFunction = <T>(promise: Promise<T>, opts: ToastPromiseOptions) => Promise<T>;
+export type ToastPromiseFunction = <T>(promise: Promise<T>, opts: ToastPromiseOptions<T>) => Promise<T>;
 
 /**
  * The custom component to rendered.
@@ -31,13 +31,13 @@ export interface ToastAddOptions {
 	opts?: ToastFunctionOptions;
 }
 
-export interface ToastPromiseOptions extends Partial<ToastFunctionOptions> {
+export interface ToastPromiseOptions<T> extends Partial<ToastFunctionOptions> {
 	/** The loading message of the promise. */
 	loading: string;
 	/** The text to be displayed if the promise is resolved. */
-	success: string;
+	success: string | ((data: T) => string);
 	/** The text to be displayed if the promise is rejected. */
-	error: string;
+	error: string | ((error: unknown) => string);
 	/** Function the run when the promise has started. */
 	onStart?: () => void;
 	/**

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -13,7 +13,7 @@ export type ToastType = 'info' | 'attention' | 'success' | 'warning' | 'error' |
 /** Simple helper to define the internal functions. */
 export type ToastFunction = (message: string, opts?: ToastFunctionOptions) => void;
 
-export type ToastPromiseFunction = (promise: Promise<any>, opts: ToastPromiseOptions) => void;
+export type ToastPromiseFunction = <T>(promise: Promise<T>, opts: ToastPromiseOptions) => Promise<T>;
 
 /**
  * The custom component to rendered.


### PR DESCRIPTION
I've made a few small tweaks to `toast.promise` to simplify some common patterns I find myself using with Svoast:

- Return the original promise to make it easier to create toasts in line

```ts
const response = await toast.promise(myApi(data), { ... });
console.log(response); // equivalent to `await myApi(data)`
```

- Allow for `success` and `error` in `ToastPromiseOptions` to be a callback that returns a string, so that messages can be generated from promise outputs

```ts
toast.promise(randomNumber(), {
  success: (n: number) => `Your number is: ${n}!`,
  error: (e: SomeError) => `Something went wrong (${e.code})`,
});
```

Happy to break these into multiple PRs if that is desirable. Also, if there's any specific examples you'd like to see in the documentation, let me know and I can update that too.