### PR TITLE
Replace `instanceof` check with `Promise.resolve()` in toast.promise

### DIFF
--- a/src/lib/state.svelte.ts
+++ b/src/lib/state.svelte.ts
@@ -98,13 +98,13 @@ class ToastState {
 	warning: ToastFunction = (message, opts = DEFAULT_OPTIONS) => this.#addToast('warning', message, { opts });
 	error: ToastFunction = (message, opts = DEFAULT_OPTIONS) => this.#addToast('error', message, { opts });
 	promise: ToastPromiseFunction = (promise, opts) => {
-		if (promise instanceof Promise === false) throw Error('`promise` is not a valid Promise.');
+		const resolvedPromise = Promise.resolve(promise);
 
 		const id = this.#addToast('promise', opts.loading, { opts });
 
 		opts.onStart?.();
 
-		promise
+		resolvedPromise
 			.then((data) => {
 				const message = typeof opts.success === 'string' ? opts.success : opts.success(data);
 				this.#addToast('success', message, { opts, id });
@@ -127,7 +127,7 @@ class ToastState {
 				opts?.onFinish?.();
 			});
 
-		return promise;
+		return resolvedPromise;
 	};
 }
 


### PR DESCRIPTION
Really enjoying using this library but have been experiencing a minor point of friction when using `toast.promise()`. The problem being that the `instanceof Promise` check fails for promise-like objects that are not strictly using the `Promise` class. This PR just swaps the promise check for a Promise.resolve() call which ensures that the value conforms to the promise interface. 

But no stress at all if this is not the direction you want to take this method :thumbsup:

Cheers!